### PR TITLE
feat: support allowing extra headers on the posthog api call

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Capturing events:
 Posthog.capture("login", distinct_id: user.id)
 ```
 
+Specifying additional headers:
+
+```elixir
+Posthog.capture("login", [distinct_id: user.id], [headers: [{"x-forwarded-for", "127.0.0.1"}]])
+```
+
 Capturing multiple events:
 
 ```elixir

--- a/lib/posthog.ex
+++ b/lib/posthog.ex
@@ -21,14 +21,15 @@ defmodule Posthog do
       :ok
       iex> Posthog.capture("login", [distinct_id: user.id], DateTime.utc_now())
       :ok
+      iex> Posthog.capture("login", [distinct_id: user.id], [headers: [{"x-forwarded-for", "127.0.0.1"}]])
 
   """
   @typep result() :: {:ok, term()} | {:error, term()}
   @typep timestamp() :: DateTime.t() | NaiveDateTime.t() | String.t() | nil
 
-  @spec capture(atom() | String.t(), keyword() | map(), timestamp()) :: result()
-  defdelegate capture(event, params, timestamp \\ nil), to: Posthog.Client
+  @spec capture(atom() | String.t(), keyword() | map(), keyword() | timestamp()) :: result()
+  defdelegate capture(event, params, opts \\ nil), to: Posthog.Client
 
-  @spec batch(list(tuple())) :: result()
-  defdelegate batch(events), to: Posthog.Client
+  @spec batch(list(tuple()), keyword()) :: result()
+  defdelegate batch(events, opts \\ nil), to: Posthog.Client
 end


### PR DESCRIPTION
example usage:
- capture("my-cool-event", [distinct_id: user.id])
- capture("my-cool-event", [distinct_id: user.id, additional_headers: [{"x-forwarded-for", "127.0.0.1"}]])
- capture("my-cool-event", %{distinct_id: user.id})
- capture("my-cool-event", %{additional_headers: %{"x-forwarded-for": "127.0.0.1"}, distinct_id: user.id})

Note: this does not support additional headers to batch events